### PR TITLE
feat: [DX-2999] add state to pkce oauth

### DIFF
--- a/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
+++ b/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
@@ -30,10 +30,12 @@ const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
     });
 
     function onWindowRedirect(url) {
+      // The finalUrl should always be the callbackUrl. Cod
+      const hasHitRedirectUrl = url.includes(callbackUrl);
       // check if the url contains an authorization code
-      if (new URL(url).searchParams.has('code')) {
+      if (hasHitRedirectUrl && new URL(url).searchParams.has('code')) {
         finalUrl = url;
-        if (!url || !finalUrl.includes(callbackUrl)) {
+        if (!url) {
           reject(new Error('Invalid Callback Url'));
         }
         window.close();

--- a/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
+++ b/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
@@ -30,7 +30,7 @@ const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
     });
 
     function onWindowRedirect(url) {
-      // The finalUrl should always be the callbackUrl. Cod
+      // The finalUrl should always be the callbackUrl.
       const hasHitRedirectUrl = url.includes(callbackUrl);
       // check if the url contains an authorization code
       if (hasHitRedirectUrl && new URL(url).searchParams.has('code')) {


### PR DESCRIPTION
State is a recommended part of the PKCE Oauth2 spec, but it is required by our identity provider (Okta). This implements support for state in a fairly straight-forward manner. We use the unique session id from the Oauth2 class (which might be the electron store?) and we make that URL safe and pass it along as a query param when the PKCE checkbox is enabled in the Oauth2 authorization code flow. 

I implemented one more fix in the oauth2 helper file, also due to okta. The code previously had a conditional that checked for a code URL parameter when in the redirect flow, but okta returned that parameter before the final redirect was reached. That meant I changed the logic to say if we're at the callback url and we see this code query parameter, then execute the rest of the code. This should be backward compatible with anything else since only the PKCE flow uses this function and callback url is a requirement of the PKCE flow. 

https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1 for more information on state

This pull request includes changes to the `packages/bruno-electron/src/ipc/network` directory that focus on improving the OAuth2 authentication process. The key changes involve enhancing the URL redirect validation in the `authorizeUserInWindow` function, simplifying the hash generation process in the `generateCodeVerifier` function, and adding a unique state parameter in the `getOAuth2AuthorizationCode` function.

URL Redirect Validation:

* [`packages/bruno-electron/src/ipc/network/authorize-user-in-window.js`](diffhunk://#diff-fbbd1a80d9b5f281110b6322a9ae6555e479eafd05147d322690ee472054a454R33-R38): The `onWindowRedirect` function now checks if the URL includes the `callbackUrl` before checking for an authorization code. This change ensures that the `finalUrl` is always the `callbackUrl`.

Hash Generation:

* [`packages/bruno-electron/src/ipc/network/oauth2-helper.js`](diffhunk://#diff-edda19bc5f544f915dde94d0d5333648f281149c57679374f9ea4c68b11b7504L10-R20): The `generateCodeChallenge` function has been renamed to `generateUniqueHash` and simplified. It now directly creates a SHA-256 hash of the input string and returns it in base64url format. This function is used to generate a unique hash for the `codeVerifier` and the `state` parameter.

OAuth2 Authorization Code Retrieval:

* [`packages/bruno-electron/src/ipc/network/oauth2-helper.js`](diffhunk://#diff-edda19bc5f544f915dde94d0d5333648f281149c57679374f9ea4c68b11b7504R47-L64): The `getOAuth2AuthorizationCode` function now generates a unique state parameter using the session ID of the collection and includes this in the OAuth2 query parameters. This change adds an extra layer of security to the OAuth2 process by mitigating cross-site request forgery attacks.